### PR TITLE
change permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,10 +12,8 @@
      "48": "icon-48.png",
      "128": "icon-128.png" },
  "permissions": [
-     "tabs",
-     "http://*/*",
-     "https://*/*"
+     "activeTab"
  ],
- "version": "0.1",
+ "version": "0.2",
  "manifest_version": 2
 }


### PR DESCRIPTION
I removed "http://\*/\*", "https://\*/\*" since they are not required.

Changed tabs with activeTab to get rid of Read your browsing history permission.

I've tested it with and it works as intended.
Microsoft Version 83.0.478.58 (Official build) (64-bit)
Google Chrome Version 86.0.4193.0 (Official Build) canary (64-bit)

